### PR TITLE
Implement `configure` command

### DIFF
--- a/lib/actions/configure.coffee
+++ b/lib/actions/configure.coffee
@@ -1,0 +1,125 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an 'AS IS' BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+_ = require('lodash')
+Promise = require('bluebird')
+umount = Promise.promisifyAll(require('umount'))
+inquirer = require('inquirer')
+reconfix = require('reconfix')
+
+CONFIGURATION_SCHEMA =
+	mapper: [
+		{
+			template:
+				hostname: '{{hostname}}'
+				'persistent-logging': '{{persistentLogging}}'
+			domain: [
+				[ 'config_json', 'hostname' ]
+				[ 'config_json', 'persistent-logging' ]
+			]
+		}
+		{
+			template:
+				wifi:
+					ssid: '{{networkSsid}}'
+				'wifi-security':
+					psk: '{{networkKey}}'
+			domain: [
+				[ 'system_connections', 'resin-wifi', 'wifi' ]
+				[ 'system_connections', 'resin-wifi', 'wifi-security' ]
+			]
+		}
+	]
+	files:
+		system_connections:
+			fileset: true
+			type: 'ini'
+			location:
+				path: 'system-connections'
+				partition:
+					primary: 1
+		config_json:
+			type: 'json'
+			location:
+				path: 'config.json'
+				partition:
+					primary: 1
+
+module.exports =
+	signature: 'configure <target>'
+	description: '(Re)configure a ResinOS drive or image'
+	help: '''
+		Use this command to configure or reconfigure a ResinOS drive or image.
+
+		Examples:
+
+			$ resin configure /dev/sdc
+			$ resin configure path/to/image.img
+	'''
+	primary: true
+	action: (params, options, done) ->
+		umount.isMountedAsync(params.target).then (isMounted) ->
+			return if not isMounted
+			umount.umountAsync(params.target)
+		.then ->
+			reconfix.readConfiguration(CONFIGURATION_SCHEMA, params.target).then (data) ->
+
+				# `persistentLogging` can be `undefined`, so we want
+				# to make sure that case defaults to `false`
+				data.persistentLogging = data.persistentLogging or false
+
+				inquirer.prompt([
+					{
+						message: 'Network SSID'
+						type: 'input'
+						name: 'networkSsid'
+						default: data.networkSsid
+					}
+					{
+						message: 'Network Key'
+						type: 'input'
+						name: 'networkKey'
+						default: data.networkKey
+					}
+					{
+						message: 'Do you want to set advanced settings?'
+						type: 'confirm'
+						name: 'advancedSettings'
+						default: false
+					}
+					{
+						message: 'Device Hostname'
+						type: 'input'
+						name: 'hostname'
+						default: data.hostname,
+						when: (answers) ->
+							answers.advancedSettings
+					}
+					{
+						message: 'Do you want to enable persistent logging?'
+						type: 'confirm'
+						name: 'persistentLogging'
+						default: data.persistentLogging
+						when: (answers) ->
+							answers.advancedSettings
+					}
+				]).then (answers) ->
+					return _.merge(data, answers)
+		.then (answers) ->
+			reconfix.writeConfiguration(CONFIGURATION_SCHEMA, answers, params.target)
+		.then ->
+			console.log('Done!')
+		.asCallback(done)

--- a/lib/actions/index.coffee
+++ b/lib/actions/index.coffee
@@ -19,3 +19,4 @@ module.exports =
 	help: require('./help')
 	sync: require('./sync')
 	ssh: require('./ssh')
+	configure: require('./configure')

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -35,6 +35,9 @@ capitano.command(actions.ssh)
 # ---------- Sync Module ----------
 capitano.command(actions.sync)
 
+# ---------- Configuration Module ----------
+capitano.command(actions.configure)
+
 # ---------- Version Module ----------
 capitano.command(actions.version)
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,12 @@
     "chalk": "^1.1.3",
     "columnify": "^1.5.4",
     "docker-toolbelt": "^1.1.0",
+    "inquirer": "^1.2.1",
     "lodash": "^4.16.2",
+    "reconfix": "0.0.3",
     "resin-cli-errors": "^1.2.0",
     "resin-sync": "^5.0.0",
+    "umount": "^1.1.3",
     "update-notifier": "^1.0.2"
   }
 }


### PR DESCRIPTION
This command accepts a drive or image target, and runs `reconfix` to
reconfigure the network connection.

Signed-off-by: Juan Cruz Viotti jviotti@openmailbox.org
