### PR TITLE
change network file name from resin-wifi to resin-sample

### DIFF
--- a/build/actions/configure.js
+++ b/build/actions/configure.js
@@ -43,7 +43,7 @@ CONFIGURATION_SCHEMA = {
           psk: '{{networkKey}}'
         }
       },
-      domain: [['system_connections', 'resin-wifi', 'wifi'], ['system_connections', 'resin-wifi', 'wifi-security']]
+      domain: [['system_connections', 'resin-sample', 'wifi'], ['system_connections', 'resin-sample', 'wifi-security']]
     }
   ],
   files: {

--- a/lib/actions/configure.coffee
+++ b/lib/actions/configure.coffee
@@ -38,8 +38,8 @@ CONFIGURATION_SCHEMA =
 				'wifi-security':
 					psk: '{{networkKey}}'
 			domain: [
-				[ 'system_connections', 'resin-wifi', 'wifi' ]
-				[ 'system_connections', 'resin-wifi', 'wifi-security' ]
+				[ 'system_connections', 'resin-sample', 'wifi' ]
+				[ 'system_connections', 'resin-sample', 'wifi-security' ]
 			]
 		}
 	]


### PR DESCRIPTION
This is because the device team pre-populate `system-connections` with resin-sample file. 
