### PR TITLE
ssh: replace ssh host alias with "s" instead of "h"

### DIFF
--- a/build/actions/ssh.js
+++ b/build/actions/ssh.js
@@ -47,7 +47,7 @@ module.exports = {
       signature: 'host',
       boolean: true,
       description: 'get a shell into the host OS',
-      alias: 'h'
+      alias: 's'
     }, {
       signature: 'container',
       parameter: 'container',

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -64,7 +64,7 @@ module.exports =
 			signature: 'host'
 			boolean: true
 			description: 'get a shell into the host OS'
-			alias: 'h'
+			alias: 's'
 	,
 			signature: 'container'
 			parameter: 'container'


### PR DESCRIPTION
Closes #44
